### PR TITLE
Added <scope>dependency</scope> to dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Please note- as of version 2.0.3 the Maven repository has changed. Update your p
     <groupId>dev.jcsoftware</groupId>
     <artifactId>JScoreboards</artifactId>
     <version>2.1.2-RELEASE</version>
+    <scope>dependency</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
The discord server is filled with people with noclassdeffound, simply saved by adding the dependency scope to the dependency.